### PR TITLE
Adjust description pointer vs. base type wrt interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ It doesn't compile: *prog.go:24: f.Foo undefined (type *Fooer is pointer to inte
 
 **Pointer recievers, non-pointer receivers and the implementation of interfaces**
 
-Pointers and the base type they point to have distinct method sets in Go. Take our implementation of the `Fooer` interface in the previous example:
+Pointers and the base type they point to have distinct method sets in Go, and this affects how you implement an interface in Go. Let's use our implementation of the `Fooer` interface in the previous example:
 
 ```go
 type Fooer interface {
@@ -106,9 +106,9 @@ func (f ImplementsFooer) Foo() int {
 
 `ImplementsFooer` and the pointer to that type, `*ImplementsFooer` are _distinct types_ in Go, and in this example only one of them implements the `Fooer` interface.
 
-Take this sample program for example:
+Given that information, please look at this sample program:
 
-```
+```go
 package main
 import "fmt"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Golang Tripping Hazards
 ---
-#####As I learn something new about Go development, I always end up finding things that I really wish someone had told me at the beginning. If you're starting to learn Go, perhaps you'll find these tidbits useful.
+##### As I learn something new about Go development, I always end up finding things that I really wish someone had told me at the beginning. If you're starting to learn Go, perhaps you'll find these tidbits useful.
 
 We hope that by sharing this list we can save new Go developers some time hitting their head against the keyboard. If you'd like to contribute something to the list, please send a Pull request.
 
@@ -84,8 +84,11 @@ func main(){
 It doesn't compile: *prog.go:24: f.Foo undefined (type *Fooer is pointer to interface, not interface).* This is because *myInstance* is of type interface, which is already a pointer. *WantsPointerToFooer* should actually accept *(f Fooer)* and you'll still get the pass-by-reference performance you're looking for.
 
 ---
+
+
 **Pointer recievers, non-pointer receivers and the implementation of interfaces**
-Pointers and the base type they point to are distinct types in Go. Take our implementation of the `Fooer` interface in the previous example:
+
+Pointers and the base type they point to have distinct method sets in Go. Take our implementation of the `Fooer` interface in the previous example:
 
 ```go
 type Fooer interface {
@@ -134,7 +137,7 @@ func printFoo(f Fooer) {
 }
 ```
 
-This program will not compile, and the compiler will give you an error when you try to compile it:
+This program will not compile. The compiler will give you an error when you try to compile it:
 
 ```
 cannot use implFoo (type ImplementsFooer) as type Fooer in argument to printFoo:


### PR DESCRIPTION
I've rewritten the description of pointers vs. base types for implementing interfaces in Go, the key to which is that the method sets for a type and a pointer to that type are different in Go. So in the example I removed from this README, you need to pass a pointer to a struct where you would use an interface in Go, as in my new example in this PR. 

In light of this, the "interfaces are always pointers" section should be adjusted; interfaces are not always pointers, but a pointer and base type are effectively two different types in Go so far as methods are concerned.

Let me know if this makes sense and any feedback you have on my changes. Thanks!